### PR TITLE
Add initial UML diagrams and README for MEI2ME

### DIFF
--- a/docs/uml/README.md
+++ b/docs/uml/README.md
@@ -1,0 +1,18 @@
+# Pacote inicial UML (PlantUML)
+
+Este pacote contém diagramas iniciais para o sistema MEI2ME:
+
+- `atores-casos-de-uso.puml`: atores e casos de uso principais.
+- `componentes-arquitetura.puml`: visão de componentes (front, backend, banco e integrações).
+- `sequencia-login-refresh.puml`: fluxo de autenticação com refresh token.
+- `sequencia-diagnostico-cnpj.puml`: fluxo de diagnóstico inicial com consulta de CNPJ.
+
+## Como renderizar
+
+Exemplo com PlantUML instalado localmente:
+
+```bash
+plantuml docs/uml/*.puml
+```
+
+Isso gera imagens `.png` no mesmo diretório.

--- a/docs/uml/atores-casos-de-uso.puml
+++ b/docs/uml/atores-casos-de-uso.puml
@@ -1,0 +1,36 @@
+@startuml
+left to right direction
+skinparam packageStyle rectangle
+skinparam actorStyle awesome
+
+actor "MEI (Usuário)" as MEI
+actor "Serviço Externo\nReceitaWS" as RECEITA
+actor "Serviço Externo\nGemini API" as GEMINI
+
+rectangle "MEI2ME" {
+  usecase "Cadastrar conta" as UC_REGISTER
+  usecase "Autenticar (login)" as UC_LOGIN
+  usecase "Recuperar senha" as UC_RECOVER
+  usecase "Preencher diagnóstico\ninicial" as UC_DIAG
+  usecase "Consultar CNPJ" as UC_CNPJ
+  usecase "Visualizar painel" as UC_DASH
+  usecase "Gerenciar checklist\nde documentos" as UC_CHECK
+  usecase "Executar simulação\nde regime" as UC_SIM
+  usecase "Acompanhar jornada\nde migração" as UC_JORNADA
+  usecase "Conversar com ContAI" as UC_CHAT
+}
+
+MEI --> UC_REGISTER
+MEI --> UC_LOGIN
+MEI --> UC_RECOVER
+MEI --> UC_DIAG
+MEI --> UC_DASH
+MEI --> UC_CHECK
+MEI --> UC_SIM
+MEI --> UC_JORNADA
+MEI --> UC_CHAT
+
+UC_DIAG .> UC_CNPJ : <<include>>
+RECEITA --> UC_CNPJ
+GEMINI --> UC_CHAT
+@enduml

--- a/docs/uml/componentes-arquitetura.puml
+++ b/docs/uml/componentes-arquitetura.puml
@@ -1,0 +1,50 @@
+@startuml
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+actor "MEI" as user
+
+node "Frontend (React + Vite)" as FE {
+  component "Rotas\n(Home/Login/Diagnóstico/AppHub)" as FE_ROUTES
+  component "Módulos\nPainel/Jornada/Checklist/Simulador" as FE_MODULES
+  component "ContAIChat" as FE_CHAT
+  component "AuthContext" as FE_AUTH
+}
+
+node "Backend (NestJS)" as BE {
+  component "AuthModule" as AUTH
+  component "DiagnosticoInicialModule" as DIAG
+  component "AnaliseMigracaoModule" as ANALISE
+  component "SimuladorRegimesModule" as SIM
+  component "ChecklistDocumentosModule" as CHECK
+  component "JornadaModule" as JORNADA
+  component "AiModule" as AI
+  component "ReceitawsApiService" as RECEITA_SVC
+  component "PrismaModule" as PRISMA
+}
+
+database "PostgreSQL" as DB
+cloud "ReceitaWS API" as RECEITA_API
+cloud "Gemini API" as GEMINI_API
+
+user --> FE_ROUTES
+FE_MODULES --> FE_AUTH
+FE_ROUTES --> BE
+FE_MODULES --> BE
+FE_CHAT --> BE
+
+BE --> PRISMA
+PRISMA --> DB
+
+DIAG --> ANALISE
+DIAG --> RECEITA_SVC
+RECEITA_SVC --> RECEITA_API
+AI --> GEMINI_API
+
+AUTH --> PRISMA
+DIAG --> PRISMA
+SIM --> PRISMA
+CHECK --> PRISMA
+JORNADA --> PRISMA
+AI --> PRISMA
+@enduml

--- a/docs/uml/sequencia-diagnostico-cnpj.puml
+++ b/docs/uml/sequencia-diagnostico-cnpj.puml
@@ -1,0 +1,33 @@
+@startuml
+autonumber
+
+actor "MEI" as User
+participant "Frontend" as FE
+participant "DiagnosticoInicialController" as DC
+participant "DiagnosticoInicialService" as DS
+participant "ReceitawsApiService" as RS
+participant "AnaliseMigracaoService" as AMS
+participant "PrismaService" as DB
+
+== Consulta CNPJ ==
+User -> FE : Digita CNPJ
+FE -> DC : GET /diagnostico-inicial/cnpj/{cnpj}
+DC -> DS : findCnpjData(cnpj)
+DS -> RS : findOne(cnpj)
+RS -> "ReceitaWS API" : GET /v1/cnpj/{cnpj}
+"ReceitaWS API" --> RS : Dados cadastrais
+RS --> DS : Dados normalizados
+DS --> DC : Dados para formulário
+DC --> FE : 200 OK
+
+== Criação do diagnóstico ==
+User -> FE : Confirma dados + envia formulário
+FE -> DC : POST /diagnostico-inicial
+DC -> DS : create(dto, user)
+DS -> AMS : analisar(mei, cnaesPermitidos)
+AMS --> DS : status/analise/motivos
+DS -> DB : upsert Mei + Diagnostico
+DB --> DS : Registro persistido
+DS --> DC : Diagnóstico consolidado
+DC --> FE : 201 Created
+@enduml

--- a/docs/uml/sequencia-login-refresh.puml
+++ b/docs/uml/sequencia-login-refresh.puml
@@ -1,0 +1,33 @@
+@startuml
+autonumber
+
+actor "MEI" as User
+participant "Frontend" as FE
+participant "AuthController" as AC
+participant "AuthService" as AS
+participant "PrismaService" as DB
+
+== Login ==
+User -> FE : Informa email/senha
+FE -> AC : POST /auth/login
+AC -> AS : login(dto)
+AS -> DB : Busca usuário por email
+DB --> AS : Dados do usuário
+AS --> AC : accessToken + refreshToken
+AC --> FE : 200 + accessToken\nSet-Cookie(refreshToken)
+
+== Refresh ==
+FE -> AC : POST /auth/refresh\n(cookie refreshToken)
+AC -> AS : refresh(refreshToken)
+AS -> DB : Valida refresh token do usuário
+DB --> AS : Usuário válido
+AS --> AC : Novo accessToken
+AC --> FE : 200 + accessToken
+
+== Logout ==
+FE -> AC : POST /auth/logout
+AC -> AS : logout(refreshToken)
+AS -> DB : Invalida refresh token
+DB --> AS : OK
+AC --> FE : 200 + clear cookie
+@enduml


### PR DESCRIPTION
### Motivation

- Add a small UML package to document MEI2ME system concepts and flows to help design and onboarding.
- Provide visual artifacts for actors/use-cases, component architecture, and two core sequences (auth and diagnostic CNPJ).

### Description

- Add `docs/uml/README.md` with a short description of included diagrams and a rendering example using `plantuml docs/uml/*.puml`.
- Add `docs/uml/atores-casos-de-uso.puml` containing actors and main use cases for the MEI user and external services.
- Add `docs/uml/componentes-arquitetura.puml` describing frontend, backend modules, database, and external APIs in a component view.
- Add `docs/uml/sequencia-login-refresh.puml` and `docs/uml/sequencia-diagnostico-cnpj.puml` with sequence diagrams for login/refresh/logout and the diagnostic CNPJ lookup and creation flows.

### Testing

- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee93ae48808326bfbad902a75d1230)